### PR TITLE
Update to use wget-improved

### DIFF
--- a/installer.js
+++ b/installer.js
@@ -6,7 +6,7 @@ const path = require('path');
 const spawn = require('cross-spawn');
 const uncompress = require('all-unpacker');
 const retryPromise = require('retrying-promise');
-const node_wget = require('node-wget');
+const node_wget = require('wget-improved');
 
 const _7zAppurl = 'http://7-zip.org/a/';
 const _7zipData = getDataForPlatform();
@@ -152,11 +152,11 @@ function getDataForPlatform() {
 function wget(path) {
     console.log('Downloading ' + path.url);
     return new Promise(function (resolve, reject) {
-        node_wget(path, function (err) {
-            if (err) {
-                console.error('Error downloading file: ' + err);
-                return reject(err);
-            }
+        let download = node_wget.download(path.url, path.dest, {});
+        download.on('error', function(err) {
+            console.error('Error downloading file: ' + err);
+        });
+        download.on('end', function(output) {
             return resolve();
         });
     });

--- a/installer.js
+++ b/installer.js
@@ -132,7 +132,7 @@ function getDataForPlatform() {
             return {
                 url:
                     'https://raw.githubusercontent.com/rudix-mac/packages/master/',
-                filename: 'p7zip-16.02.pkg',
+                filename: 'p7zip-16.02-macos10.15.pkg',
                 extraname: 'lzma1604.7z',
                 extractfolder: '',
                 applocation: 'usr/local/lib/p7zip',

--- a/installer.js
+++ b/installer.js
@@ -155,6 +155,7 @@ function wget(path) {
         let download = node_wget.download(path.url, path.dest, {});
         download.on('error', function(err) {
             console.error('Error downloading file: ' + err);
+            return reject(err);
         });
         download.on('end', function(output) {
             return resolve();

--- a/installer.js
+++ b/installer.js
@@ -132,7 +132,7 @@ function getDataForPlatform() {
             return {
                 url:
                     'https://raw.githubusercontent.com/rudix-mac/packages/master/',
-                filename: 'p7zip-16.02-macos10.15.pkg',
+                filename: 'p7zip-16.02.pkg',
                 extraname: 'lzma1604.7z',
                 extractfolder: '',
                 applocation: 'usr/local/lib/p7zip',

--- a/package.json
+++ b/package.json
@@ -52,9 +52,9 @@
         "all-unpacker": "^0.1.3",
         "fs-extra": "^8.0.0",
         "macos-release": "^2.0.0",
-        "node-wget": "^0.4.2",
         "retrying-promise": "^0.0.4",
-        "system-installer": "^1.1.0"
+        "system-installer": "^1.1.0",
+        "wget-improved": "3.2.1"
     },
     "devDependencies": {
         "chai": "^4.1.2",


### PR DESCRIPTION
This package appears to not have the same security warnings..  I ran the `npm audit` and it's clean.
We'll submit the same fix in `node-unpack-all` repo.. 
https://github.com/techno-express/node-unpack-all/pull/1
Thanks!
